### PR TITLE
fix: overflow set to auto instead of scroll

### DIFF
--- a/components/Callout.tsx
+++ b/components/Callout.tsx
@@ -40,7 +40,7 @@ export default function Callout({ children, type = "default", icon }) {
 
   return (
     <div
-      className={`${theme.classes} flex rounded-lg callout mt-6 overflow-scroll`}
+      className={`${theme.classes} flex rounded-lg callout mt-6 overflow-auto`}
     >
       <div
         className="py-2 pl-3 pr-2 text-xl select-none"


### PR DESCRIPTION
## 📑 Description
I have added `overflow-auto` on the callout component instead of `overflow-scroll` so that scrollbar appears only when it is necessary. 

**Previous :** 
![image](https://github.com/thatbeautifuldream/100xdocs/assets/65642985/adc99902-23a5-40d4-88c5-1876a5604d68)

**Now**
![image](https://github.com/thatbeautifuldream/100xdocs/assets/65642985/40b696dd-be36-404e-a25b-c00adf9c40c7)

## ✅ Checks

<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->

- [x] My pull request adheres to the code style of this project
- [x] My code requires changes to the documentation
- [x] I have updated the documentation as required
- [x] All the tests have passed